### PR TITLE
Fix issue with multiple calls

### DIFF
--- a/frontend/components/ContributionsRow.tsx
+++ b/frontend/components/ContributionsRow.tsx
@@ -170,10 +170,10 @@ export const ContributionsRow = ({
         py={7}
         borderTop={"1px solid #000000"}
       >
-        <YourContributions
-          account={account}
-          burntPixArchives={burntPixArchives}
-        />
+          <YourContributions
+            account={account}
+            burntPixArchives={burntPixArchives}
+          /> 
       </GridItem>
     </Grid>
   );

--- a/frontend/components/ContributionsRow.tsx
+++ b/frontend/components/ContributionsRow.tsx
@@ -170,10 +170,10 @@ export const ContributionsRow = ({
         py={7}
         borderTop={"1px solid #000000"}
       >
-          <YourContributions
-            account={account}
-            burntPixArchives={burntPixArchives}
-          /> 
+        <YourContributions
+          account={account}
+          burntPixArchives={burntPixArchives}
+        />
       </GridItem>
     </Grid>
   );

--- a/frontend/components/Home.tsx
+++ b/frontend/components/Home.tsx
@@ -99,7 +99,7 @@ export default function Home() {
   return (
     <main className={styles.main}>
       <Flex width="100%" direction={"column"} maxW={"2000px"} px={8}>
-        <Header winnerIterations={winnerIterations} />
+        {/* <Header winnerIterations={winnerIterations} />
         <OverviewRow
           collectionStats={collectionStats}
           burntPicId={burntPicId}
@@ -108,7 +108,7 @@ export default function Home() {
           account={account}
           burntPixArchives={burntPixArchives}
           networkConfig={networkConfig}
-        />
+        /> */}
       </Flex>
     </main>
   );

--- a/frontend/components/Home.tsx
+++ b/frontend/components/Home.tsx
@@ -99,7 +99,7 @@ export default function Home() {
   return (
     <main className={styles.main}>
       <Flex width="100%" direction={"column"} maxW={"2000px"} px={8}>
-        {/* <Header winnerIterations={winnerIterations} />
+        <Header winnerIterations={winnerIterations} />
         <OverviewRow
           collectionStats={collectionStats}
           burntPicId={burntPicId}
@@ -108,7 +108,7 @@ export default function Home() {
           account={account}
           burntPixArchives={burntPixArchives}
           networkConfig={networkConfig}
-        /> */}
+        />
       </Flex>
     </main>
   );

--- a/frontend/components/Leaderboard.tsx
+++ b/frontend/components/Leaderboard.tsx
@@ -112,6 +112,12 @@ const Leaderboard: React.FC = () => {
         return { upName: null, avatar: null };
       }
 
+      const existingContributor = sortedContributions.find((c) => c.contributor === contributor);
+      // avoid unnecessary api call when refreshing leaderboard
+      if (existingContributor) {
+        return { upName: existingContributor.upName, avatar: existingContributor.avatar };
+      }
+
       const profileData = await getProfileData(contributor, rpcUrl);
       let upName = null,
         avatar = null;

--- a/frontend/components/Leaderboard.tsx
+++ b/frontend/components/Leaderboard.tsx
@@ -45,9 +45,13 @@ const Leaderboard: React.FC = () => {
 
   useEffect(() => {
     let isMounted = true;
-    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
-  
-    const fetchProfileDataWithDelay = async (contributors: string[], delayMs: number) => {
+    const delay = (ms: number) =>
+      new Promise((resolve) => setTimeout(resolve, ms));
+
+    const fetchProfileDataWithDelay = async (
+      contributors: string[],
+      delayMs: number,
+    ) => {
       const profiles = [];
       for (const contrib of contributors) {
         if (!isMounted) return;
@@ -57,26 +61,32 @@ const Leaderboard: React.FC = () => {
       }
       return profiles;
     };
-  
+
     const fetchContributions = async () => {
       setIsLoading(true);
       try {
-        const [topContributors, contributions] = await burntPixArchives.getTopTenContributors();
+        const [topContributors, contributions] =
+          await burntPixArchives.getTopTenContributors();
         if (Number(contributions[0]) === 0 || !isMounted) {
           return;
         }
-        const delayMsTime = 150
-  
-        const profiles = await fetchProfileDataWithDelay(topContributors, delayMsTime);
+        const delayMsTime = 150;
+
+        const profiles = await fetchProfileDataWithDelay(
+          topContributors,
+          delayMsTime,
+        );
         if (!isMounted || !profiles) return;
-  
-        const contributionsWithProfiles = topContributors.map((contributor, index) => ({
-          contributor,
-          contribution: Number(contributions[index]),
-          upName: profiles[index]?.upName || null,
-          avatar: profiles[index]?.avatar || null,
-        }));
-  
+
+        const contributionsWithProfiles = topContributors.map(
+          (contributor, index) => ({
+            contributor,
+            contribution: Number(contributions[index]),
+            upName: profiles[index]?.upName || null,
+            avatar: profiles[index]?.avatar || null,
+          }),
+        );
+
         if (isMounted) setSortedContributions(contributionsWithProfiles);
       } catch (error: any) {
         if (isMounted) {
@@ -92,30 +102,32 @@ const Leaderboard: React.FC = () => {
         if (isMounted) setIsLoading(false);
       }
     };
-  
+
     fetchContributions();
-  
+
     return () => {
       isMounted = false;
     };
   }, [refineEventCounter]);
-  
 
   const fetchProfileData = async (
     contributor: string,
     rpcUrl: string,
   ): Promise<{ upName: string | null; avatar: string | null } | null> => {
     try {
-
-      if (contributor === "0x0000000000000000000000000000000000000000"
-      ) {
+      if (contributor === "0x0000000000000000000000000000000000000000") {
         return { upName: null, avatar: null };
       }
 
-      const existingContributor = sortedContributions.find((c) => c.contributor === contributor);
+      const existingContributor = sortedContributions.find(
+        (c) => c.contributor === contributor,
+      );
       // avoid unnecessary api call when refreshing leaderboard
       if (existingContributor) {
-        return { upName: existingContributor.upName, avatar: existingContributor.avatar };
+        return {
+          upName: existingContributor.upName,
+          avatar: existingContributor.avatar,
+        };
       }
 
       const profileData = await getProfileData(contributor, rpcUrl);

--- a/frontend/components/Leaderboard.tsx
+++ b/frontend/components/Leaderboard.tsx
@@ -44,49 +44,74 @@ const Leaderboard: React.FC = () => {
   );
 
   useEffect(() => {
+    let isMounted = true;
+    const delay = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+  
+    const fetchProfileDataWithDelay = async (contributors: string[], delayMs: number) => {
+      const profiles = [];
+      for (const contrib of contributors) {
+        if (!isMounted) return;
+        const profile = await fetchProfileData(contrib, networkConfig.rpcUrl);
+        profiles.push(profile);
+        await delay(delayMs);
+      }
+      return profiles;
+    };
+  
     const fetchContributions = async () => {
+      setIsLoading(true);
       try {
-        const [topContributors, contributions] =
-          await burntPixArchives.getTopTenContributors();
-        if (Number(contributions[0]) === 0) {
+        const [topContributors, contributions] = await burntPixArchives.getTopTenContributors();
+        if (Number(contributions[0]) === 0 || !isMounted) {
           return;
         }
-
-        const profiles = await Promise.all(
-          topContributors.map((contrib) =>
-            fetchProfileData(contrib, networkConfig.rpcUrl),
-          ),
-        );
-        const contributionsWithProfiles = topContributors.map(
-          (contributor, index) => ({
-            contributor,
-            contribution: Number(contributions[index]),
-            upName: profiles[index]?.upName || null,
-            avatar: profiles[index]?.avatar || null,
-          }),
-        );
-
-        setSortedContributions(contributionsWithProfiles);
+        const delayMsTime = 150
+  
+        const profiles = await fetchProfileDataWithDelay(topContributors, delayMsTime);
+        if (!isMounted || !profiles) return;
+  
+        const contributionsWithProfiles = topContributors.map((contributor, index) => ({
+          contributor,
+          contribution: Number(contributions[index]),
+          upName: profiles[index]?.upName || null,
+          avatar: profiles[index]?.avatar || null,
+        }));
+  
+        if (isMounted) setSortedContributions(contributionsWithProfiles);
       } catch (error: any) {
-        toast({
-          title: `Failed to fetch leaderboard contributions: ${error.message}`,
-          status: "error",
-          position: "bottom-left",
-          duration: null,
-          isClosable: true,
-        });
+        if (isMounted) {
+          toast({
+            title: `Failed to fetch leaderboard contributions: ${error.message}`,
+            status: "error",
+            position: "bottom-left",
+            duration: null,
+            isClosable: true,
+          });
+        }
       } finally {
-        setIsLoading(false);
+        if (isMounted) setIsLoading(false);
       }
     };
+  
     fetchContributions();
-  }, [refineEventCounter]); // NOTE: adding dependencies will cause duplicated calls
+  
+    return () => {
+      isMounted = false;
+    };
+  }, [refineEventCounter]);
+  
 
   const fetchProfileData = async (
     contributor: string,
     rpcUrl: string,
   ): Promise<{ upName: string | null; avatar: string | null } | null> => {
     try {
+
+      if (contributor === "0x0000000000000000000000000000000000000000"
+      ) {
+        return { upName: null, avatar: null };
+      }
+
       const profileData = await getProfileData(contributor, rpcUrl);
       let upName = null,
         avatar = null;

--- a/frontend/components/wallet/WalletProvider.tsx
+++ b/frontend/components/wallet/WalletProvider.tsx
@@ -9,13 +9,6 @@ import { JsonRpcProvider, BrowserProvider } from "ethers";
 import { buildSIWEMessage } from "@/utils/universalProfile";
 import { ethers } from "ethers";
 import { BurntPixArchives__factory } from "@/contracts";
-import {
-  Multicall,
-  ContractCallResults,
-  ContractCallContext,
-} from 'ethereum-multicall';
-import { TimeoutError } from "viem";
-import { time } from "console";
 
 // Extends the window object to include `lukso`, which will be used to interact with LUKSO blockchain.
 declare global {
@@ -40,17 +33,16 @@ export const WalletProvider: React.FC<Props> = ({ children }) => {
   const networkConfig = getNetworkConfig(
     process.env.NEXT_PUBLIC_DEFAULT_NETWORK!,
   );
-  const [provider, setProvider] = useState<JsonRpcProvider | BrowserProvider | any>(
+  const [provider, setProvider] = useState<JsonRpcProvider | BrowserProvider>(
     DEFAULT_PROVIDER,
   );
-
-  // const multicall = new Multicall({ ethersProvider: provider, tryAggregate: true });
 
   const [refineEventCounter, setRefineEventCounter] = useState(0);
   const [account, setAccount] = useState<string | null>(null);
   const [mainUPController, setMainUPController] = useState<string>();
   const [isLoadingAccount, setIsLoadingAccount] = useState<boolean>(true);
-  const [isListeningToRefineToArchive, setIsListeningToRefineToArchive] = useState<boolean>(false); // sanity check to avoid multiple listeners
+  const [isListeningToRefineToArchive, setIsListeningToRefineToArchive] =
+    useState<boolean>(false); // sanity check to avoid multiple listeners
   const [connectedChainId, setConnectedChainId] = useState<
     number | undefined
   >();
@@ -64,7 +56,7 @@ export const WalletProvider: React.FC<Props> = ({ children }) => {
   // Listen to the RefineToArchive event
   // that will refresh component
   useEffect(() => {
-    if (isListeningToRefineToArchive) { 
+    if (isListeningToRefineToArchive) {
       return;
     }
     const TIMEOUT = 4000;
@@ -199,14 +191,12 @@ export const WalletProvider: React.FC<Props> = ({ children }) => {
     };
 
     try {
-      console.log("LISTENING TO REFINE TO ARCHIVE EVENT")
+      console.log("LISTENING TO REFINE TO ARCHIVE EVENT");
       contract.on("RefineToArchive", (sender, value) => {
         console.log("REFINE TO ARCHIVE EVENT", sender, value);
         setRefineEventCounter((prevCounter) => {
-          return prevCounter + 1
-        }
-        
-        );
+          return prevCounter + 1;
+        });
       });
     } catch (error) {
       console.error("Error listening to RefineToArchive event", error);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,7 +25,6 @@
     "encoding": "^0.1.13",
     "eslint": "8.42.0",
     "eslint-config-next": "13.4.4",
-    "ethereum-multicall": "^2.23.0",
     "ethers": "^6.11.1",
     "framer-motion": "^11.0.20",
     "fs": "^0.0.1-security",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -25,6 +25,7 @@
     "encoding": "^0.1.13",
     "eslint": "8.42.0",
     "eslint-config-next": "13.4.4",
+    "ethereum-multicall": "^2.23.0",
     "ethers": "^6.11.1",
     "framer-motion": "^11.0.20",
     "fs": "^0.0.1-security",


### PR DESCRIPTION
-> delay start of listener 4 seconds since page load
-> Cause of the main issue : fetch profile data in leaderboard
-> Don't fetch data for 0x00000 addresses
-> Don't fetch data if we already have it for that wallet
-> Fetch profile data with a delay between the calls
-> Leaderboard separated in 2 rows and load separated